### PR TITLE
Update Praxent page intro and add three project highlight blocks

### DIFF
--- a/praxent.html
+++ b/praxent.html
@@ -84,12 +84,163 @@
 
                 <div class="rightTextContainer">
                     <p class="subheadline doggy">
-                        Coming Soon!
-                        <br><br>
-                        Just imagine me running around an office like this doggy for now.
-
+                        At Praxent, I joined a product consultancy focused on launching human-centered digital
+                        experiences. I partnered with strategy, UX, and engineering teams to take products from
+                        discovery to delivery for clients across fintech, healthcare, and mission-driven
+                        organizations.
+                    </p>
+                    <br>
+                    <p class="subheadline"><span class="detail">↓</span> See below for highlights
                     </p>
 
+                </div>
+            </div>
+
+            <div class="greyBackground">
+                <img class="UI center-gif smallGif" src="./assets/img-vid/praxentteam.jpeg"></img>
+                <div class="contentPageTextContainer">
+                    <div class="leftTextContainer contentPageText">
+                        <p class="h1">
+                            <b><i>Financial Wellness Platform</i></b><br> Client project
+                        </p>
+                    </div>
+                    <div class="rightTextContainer contentPageText">
+                        <div class="row">
+                            <div class="col-6">
+                                Location
+                                <p class="subheadline">
+                                    Austin, TX
+                                </p>
+                            </div>
+                            <div class="col-6 pl-5">
+                                Timeline
+                                <p class="subheadline">
+                                    March to September 2020
+                                </p>
+                            </div>
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col">
+                                Product Designer<br>
+                                <p class="subheadline">
+                                    Led user flows and UI design for a mobile-first financial wellness experience,
+                                    collaborating with client stakeholders to align on goals and deliverables. The
+                                    team focused on simplifying budgeting, savings, and coaching features for everyday
+                                    users. <br>
+                                    <ul class="mt-3 pl-4 bullets subheadline">
+                                        <li><i>Discovery and Research</i></li>
+                                        <ul class="bullets subheadline">
+                                            <li>Mapped personas and journey flows to uncover high-friction moments</li>
+                                            <li>Translated insights into prioritized MVP features for launch</li>
+                                        </ul>
+                                        <li><i>Experience Design</i></li>
+                                        <ul class="bullets subheadline">
+                                            <li>Created low-to-high fidelity prototypes for weekly client reviews</li>
+                                            <li>Partnered with engineering to deliver responsive design specs</li>
+                                        </ul>
+                                    </ul>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="whiteBackground">
+                <img class="UI center-gif smallGif" src="./assets/img-vid/garajeCommunity.png"></img>
+                <div class="contentPageTextContainer">
+                    <div class="leftTextContainer contentPageText">
+                        <p class="h1">
+                            <b><i>Garaje Community Platform</i></b><br> Client project
+                        </p>
+                    </div>
+                    <div class="rightTextContainer contentPageText">
+                        <div class="row">
+                            <div class="col-6">
+                                Location
+                                <p class="subheadline">
+                                    Houston, TX
+                                </p>
+                            </div>
+                            <div class="col-6 pl-5">
+                                Timeline
+                                <p class="subheadline">
+                                    October 2020 to February 2021
+                                </p>
+                            </div>
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col">
+                                UX/UI Designer<br>
+                                <p class="subheadline">
+                                    Designed a community experience for entrepreneurs to connect with events,
+                                    mentorship, and resources. Worked alongside product owners to define feature
+                                    scope and ensure consistent, accessible layouts across devices. <br>
+                                    <ul class="mt-3 pl-4 bullets subheadline">
+                                        <li><i>Design System</i></li>
+                                        <ul class="bullets subheadline">
+                                            <li>Established UI components and typography for scalable reuse</li>
+                                            <li>Documented interaction patterns for web and mobile views</li>
+                                        </ul>
+                                        <li><i>Prototyping and Testing</i></li>
+                                        <ul class="bullets subheadline">
+                                            <li>Built interactive prototypes to validate navigation and content</li>
+                                            <li>Iterated on layouts based on stakeholder and user feedback</li>
+                                        </ul>
+                                    </ul>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="greyBackground">
+                <img class="UI center-gif smallGif" src="./assets/img-vid/guru-match-screen-2.png"></img>
+                <div class="contentPageTextContainer">
+                    <div class="leftTextContainer contentPageText">
+                        <p class="h1">
+                            <b><i>Coaching Marketplace Experience</i></b><br> Internal project
+                        </p>
+                    </div>
+                    <div class="rightTextContainer contentPageText">
+                        <div class="row">
+                            <div class="col-6">
+                                Location
+                                <p class="subheadline">
+                                    Remote
+                                </p>
+                            </div>
+                            <div class="col-6 pl-5">
+                                Timeline
+                                <p class="subheadline">
+                                    March to July 2021
+                                </p>
+                            </div>
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col">
+                                Lead Product Designer<br>
+                                <p class="subheadline">
+                                    Concepted a marketplace that connects clients with coaches and advisors, focusing
+                                    on clear search, matching, and onboarding flows. Collaborated with a small internal
+                                    team to deliver design artifacts for development. <br>
+                                    <ul class="mt-3 pl-4 bullets subheadline">
+                                        <li><i>Matching Flows</i></li>
+                                        <ul class="bullets subheadline">
+                                            <li>Designed profile and preference flows for faster pairing</li>
+                                            <li>Iterated on feedback loops to improve conversion</li>
+                                        </ul>
+                                        <li><i>Launch Preparation</i></li>
+                                        <ul class="bullets subheadline">
+                                            <li>Documented UI specs and asset exports for engineers</li>
+                                            <li>Defined a backlog of post-launch enhancements and optimizations</li>
+                                        </ul>
+                                    </ul>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
### Motivation
- Mirror the `pwc.html` structure by replacing the placeholder intro and surfacing highlights for Praxent.
- Provide a concise, descriptive overview of the Praxent role instead of the “Coming Soon!” message.
- Add three project highlight sections that alternate `.greyBackground` and `.whiteBackground` to match existing visual styling.
- Maintain the existing footer and JavaScript includes unchanged for site consistency.

### Description
- Replaced the `.mainContainer` right-column copy with a Praxent overview and a `↓ See below for highlights` prompt to match the PwC pattern.
- Added three content blocks inside `.mainContentContainerContentPage` using alternating `greyBackground`/`whiteBackground` classes, each following the same structure used in `pwc.html` (image, left title/tag column, right details column).
- Inserted project content and images (using `./assets/img-vid/...`) for `Financial Wellness Platform`, `Garaje Community Platform`, and `Coaching Marketplace Experience`, including location, timeline, role, descriptive paragraphs, and bullet lists.
- Left footer markup and all JS includes untouched to avoid behavioral changes.

### Testing
- Started a local static server with `python -m http.server 8000` and confirmed the site was served successfully.
- Rendered `praxent.html` and captured a full-page screenshot using Playwright, which completed without errors.
- No unit or integration tests were applicable for this static HTML update.
- Visual inspection via the generated screenshot validated the new content blocks and layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e08179e8833387e2553703d15988)